### PR TITLE
NutanixTask: handle unset start_time

### DIFF
--- a/src/nutanix_api/nutanix_task.py
+++ b/src/nutanix_api/nutanix_task.py
@@ -27,11 +27,11 @@ class NutanixTask(BaseEntity):
         uuid: str,
         status: str,
         entity_reference_list: List[Dict[str, Any]],
-        start_time: str,
         creation_time: str,
         last_update_time: str,
         percentage_complete: int,
         progress_message: str,
+        start_time: str = None,
         completion_time: str = None,
         **_,
     ) -> None:
@@ -42,7 +42,7 @@ class NutanixTask(BaseEntity):
         self._status: TaskStatus = TaskStatus(status)
         self._progress_message: str = progress_message
         self._entity_reference: List[Dict[str, Any]] = entity_reference_list
-        self._start_time: datetime = parser.parse(start_time)
+        self._start_time: datetime = parser.parse(start_time) if start_time else None
         self._creation_time: datetime = parser.parse(creation_time)
         self._completion_time: datetime = parser.parse(completion_time) if completion_time else None
         self._last_update_time: datetime = parser.parse(last_update_time)


### PR DESCRIPTION
We may want to do operations (like set boot order) on VMs which are not
yet started, so __init__ should handle unset start_time.

Fixes a crash in assisted-test-infra:
```
 ________________________ TestInstall.test_install[4.12] ________________________

self = <tests.test_e2e_install.TestInstall object at 0x7f666333fc70>
cluster = <assisted_test_infra.test_infra.helper_classes.cluster.Cluster object at 0x7f66633beb00>
openshift_version = '4.12'

    @JunitTestSuite()
    @pytest.mark.parametrize("openshift_version", get_available_openshift_versions())
    def test_install(self, cluster, openshift_version):
>       cluster.prepare_for_installation()

src/tests/test_e2e_install.py:13: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python3.10/site-packages/decorator.py:232: in fun
    return caller(func, *(extras + args), **kw)
/usr/local/lib/python3.10/site-packages/junit_report/decorators/_junit_decorator.py:31: in wrapper
    return self._wrapper(function, *args, **kwargs)
/usr/local/lib/python3.10/site-packages/junit_report/decorators/_junit_decorator.py:53: in _wrapper
    self._on_exception(e)
/usr/local/lib/python3.10/site-packages/junit_report/decorators/_junit_test_case.py:51: in _on_exception
    raise e
/usr/local/lib/python3.10/site-packages/junit_report/decorators/_junit_decorator.py:51: in _wrapper
    value = self._execute_wrapped_function(*args, **kwargs)
/usr/local/lib/python3.10/site-packages/junit_report/decorators/_junit_decorator.py:93: in _execute_wrapped_function
    return self._func(*args, **kwargs)
src/assisted_test_infra/test_infra/helper_classes/cluster.py:888: in prepare_for_installation
    super(Cluster, self).prepare_for_installation(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
src/assisted_test_infra/test_infra/helper_classes/entity.py:72: in prepare_for_installation
    self.nodes.prepare_nodes()
src/assisted_test_infra/test_infra/helper_classes/nodes.py:127: in prepare_nodes
    self.controller.prepare_nodes()
src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py:35: in prepare_nodes
    self.set_boot_order(node.name)
src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py:168: in set_boot_order
    vm.update_boot_order([VMBootDevices.DISK, VMBootDevices.CDROM, VMBootDevices.NETWORK])
/usr/local/lib/python3.10/site-packages/nutanix_api/nutanix_vm.py:206: in update_boot_order
    return self.update_entity(wait, timeout=timeout)
/usr/local/lib/python3.10/site-packages/nutanix_api/entity.py:129: in update_entity
    task = NutanixTask.get(self._api_client, result["status"].get("execution_context", {}).get("task_uuid"))
/usr/local/lib/python3.10/site-packages/nutanix_api/nutanix_task.py:90: in get
    return cls.get_from_info(api_client, entity_info)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'nutanix_api.nutanix_task.NutanixTask'>
api_client = <nutanix_api.api_client.NutanixApiClient object at 0x7f66633bea40>
info = {'api_version': '3.1', 'cluster_reference': {'kind': 'cluster', 'uuid': 'cb4a742c-2626-45bc-8109-df53660d1ab0'}, 'creation_time': '2022-10-11T15:59:46Z', 'creation_time_usecs': 1665503986717451, ...}

    @classmethod
    def get_from_info(cls, api_client: NutanixApiClient, info: Dict[str, Any]) -> "NutanixTask":
>       return cls(api_client, **info)
E       TypeError: NutanixTask.__init__() missing 1 required positional argument: 'start_time'
```