### PR TITLE
Allow a wider range of versions for installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,12 @@ setuptools.setup(
     license="MIT",
     packages=setuptools.find_packages("src"),
     package_dir={"": "src"},
-    install_requires=requirements,
+    install_requires=[
+        "requests",
+        "urllib3",
+        "waiting",
+        "python-dateutil",
+    ],
     tests_require=requirements + test_requirements,
     include_package_data=True,
     python_requires=">=3.7.0",


### PR DESCRIPTION
When specifying requirements in ``setup.py`` they need to be pretty general and not pinned to specific versions, otherwise the depending code cannot upgrade its dependencies independently. For example:

```
The conflict is caused by:
    The user requested requests==2.31.0
    kubernetes 26.1.0 depends on requests
    nutanix-api 0.0.19 depends on requests~=2.28.1
```

(taken from
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/2168/pull-ci-openshift-assisted-test-infra-master-lint/1660790807138930688)